### PR TITLE
Disable links preview in posts

### DIFF
--- a/commands/publishCV.js
+++ b/commands/publishCV.js
@@ -40,7 +40,9 @@ async function publish(msg) {
 
   // send to channel
   const channelMessage = formatVacancy(msg.reply_to_message.text, msg.chat.username);
-  const { message_id: channelMessageId } = await bot.sendMessage(channel, channelMessage);
+  const { message_id: channelMessageId } = await bot.sendMessage(channel, channelMessage, {
+    disable_web_page_preview: true,
+  });
   debug('publish:channelMessage', channelMessage);
   debug('publish:channelMessageId', channelMessageId);
 

--- a/commands/publishVacancy.js
+++ b/commands/publishVacancy.js
@@ -37,7 +37,9 @@ async function publish(msg) {
 
   // send to channel
   const channelMessage = formatVacancy(msg.reply_to_message.text, msg.chat.username);
-  const { message_id: channelMessageId } = await bot.sendMessage(channel, channelMessage);
+  const { message_id: channelMessageId } = await bot.sendMessage(channel, channelMessage, {
+    disable_web_page_preview: true,
+  });
   debug('publish:channelMessage', channelMessage);
   debug('publish:channelMessageId', channelMessageId);
 


### PR DESCRIPTION
Превью аватарок от ссылок `t.me` в канале не нужны, в клиенте на macos и android занимает всю ширину поста (в других не проверял).